### PR TITLE
feat: add support for min cas anchor workers

### DIFF
--- a/cd/manager/jobmanager/jobManager.go
+++ b/cd/manager/jobmanager/jobManager.go
@@ -26,6 +26,7 @@ type JobManager struct {
 	repo          manager.Repository
 	notifs        manager.Notifs
 	maxAnchorJobs int
+	minAnchorJobs int
 	paused        bool
 	env           manager.EnvType
 	waitGroup     *sync.WaitGroup
@@ -38,8 +39,18 @@ func NewJobManager(cache manager.Cache, db manager.Database, d manager.Deploymen
 			maxAnchorJobs = parsedMaxAnchorWorkers
 		}
 	}
+	minAnchorJobs := manager.DefaultCasMinAnchorWorkers
+	if configMinAnchorWorkers, found := os.LookupEnv("CAS_MIN_ANCHOR_WORKERS"); found {
+		if parsedMinAnchorWorkers, err := strconv.Atoi(configMinAnchorWorkers); err == nil {
+			minAnchorJobs = parsedMinAnchorWorkers
+		}
+	}
+	// Sanity check the counts
+	if minAnchorJobs > maxAnchorJobs {
+		minAnchorJobs = maxAnchorJobs
+	}
 	paused, _ := strconv.ParseBool(os.Getenv("PAUSED"))
-	return &JobManager{cache, db, d, apiGw, repo, notifs, maxAnchorJobs, paused, manager.EnvType(os.Getenv("ENV")), new(sync.WaitGroup)}, nil
+	return &JobManager{cache, db, d, apiGw, repo, notifs, maxAnchorJobs, minAnchorJobs, paused, manager.EnvType(os.Getenv("ENV")), new(sync.WaitGroup)}, nil
 }
 
 func (m *JobManager) NewJob(jobState manager.JobState) (string, error) {
@@ -135,6 +146,10 @@ func (m *JobManager) processJobs() {
 	}
 	// Don't start any new jobs if the job manager is paused. Existing jobs will continue to be advanced.
 	if !m.paused {
+		// Always check if we have anchor jobs, even if none were dequeued. This is because we might have a minimum
+		// number of jobs to run configured. The only time we don't want to run anchor jobs is when a deployment is
+		// kicked off.
+		processAnchorJobs := true
 		// Try to dequeue multiple jobs and collapse similar ones:
 		// - one deploy at a time
 		// - any number of anchor workers (compatible with with smoke/E2E tests)
@@ -159,23 +174,25 @@ func (m *JobManager) processJobs() {
 			dequeuedJobs = tempSlice
 			// Recheck the length of `dequeuedJobs` in case any job(s) failed preprocessing and got filtered out
 			if len(dequeuedJobs) > 0 {
-				// Check for any force deploy jobs, and only look at the remaining jobs if no deployments were kicked-off.
-				if !m.processForceDeployJobs(dequeuedJobs) {
-					// Decide how to proceed based on the first job from the list
-					if dequeuedJobs[0].Type == manager.JobType_Deploy {
-						if !m.processDeployJobs(dequeuedJobs) {
-							// If no deploy jobs were launched, process pending anchor jobs. We don't want to hold on to
-							// anchor jobs queued behind deploys because tests need anchors to run, and deploys can't run
-							// till tests complete.
-							m.processAnchorJobs(dequeuedJobs)
-						}
-					} else {
-						// Test and anchor jobs can run in parallel
-						m.processTestJobs(dequeuedJobs)
-						m.processAnchorJobs(dequeuedJobs)
-					}
+				// Check for any force deploy jobs, and only look at the remaining jobs if no deployments were kicked
+				// off.
+				if m.processForceDeployJobs(dequeuedJobs) {
+					processAnchorJobs = false
+				} else
+				// Decide how to proceed based on the first job from the list
+				if dequeuedJobs[0].Type == manager.JobType_Deploy {
+					processAnchorJobs = !m.processDeployJobs(dequeuedJobs)
+				} else {
+					m.processTestJobs(dequeuedJobs)
 				}
 			}
+		}
+		// If no deploy jobs were launched, process pending anchor jobs. We don't want to hold on to anchor jobs queued
+		// behind deploys because tests need anchors to run, and deploys can't run till tests complete.
+		//
+		// Test and anchor jobs can run in parallel.
+		if processAnchorJobs {
+			m.processAnchorJobs(dequeuedJobs)
 		}
 	}
 	// Wait for all of this iteration's job advancement goroutines to finish before we iterate again. The ticker will
@@ -360,7 +377,17 @@ func (m *JobManager) processAnchorJobs(dequeuedJobs []manager.JobState) bool {
 			log.Printf("processAnchorJobs: starting anchor job: %s", manager.PrintJob(anchorJob))
 			m.advanceJob(anchorJob)
 		}
-		return len(dequeuedAnchors) > 0
+		// If not enough anchor jobs were queued by the scheduler to meet the configured minimum number of workers, add
+		// jobs to the queue to make up the difference. These jobs should get picked up in a subsequent job manager
+		// iteration, properly coordinated with other jobs in the queue. It's ok if we ultimately end up with more jobs
+		// than the configured maximum number of workers - the actual number of jobs run will be capped correctly.
+		numJobs := len(dequeuedAnchors)
+		for i := 0; i < m.minAnchorJobs-numJobs; i++ {
+			if _, err := m.NewJob(manager.JobState{Type: manager.JobType_Anchor}); err != nil {
+				log.Printf("processAnchorJobs: failed to queue additional anchor job: %v", err)
+			}
+		}
+		return numJobs > 0
 	} else {
 		log.Printf("processAnchorJobs: deployment in progress")
 	}

--- a/cd/manager/models.go
+++ b/cd/manager/models.go
@@ -148,6 +148,7 @@ const (
 const ResourceTag = "Ceramic"
 const ServiceName = "cd-manager"
 const DefaultCasMaxAnchorWorkers = 1
+const DefaultCasMinAnchorWorkers = 0
 
 // JobState represents the state of a job in the database
 type JobState struct {

--- a/cd/manager/models.go
+++ b/cd/manager/models.go
@@ -76,6 +76,7 @@ const (
 	JobParam_Rollback  string = "rollback"
 	JobParam_Delayed   string = "delayed"
 	JobParam_Stalled   string = "stalled"
+	JobParam_Source    string = "source"
 )
 
 type DeployComponent string


### PR DESCRIPTION
The new env variable sets a min number of CAS anchor jobs that should always be active, barring when a deployment is in progress.

This will always keep the configured minimum number of workers running, effectively running anchor jobs "in a loop".

This logic also incorporates any jobs created by the scheduler.