### PR TITLE
ci: pin dagger version to 0.2.36

### DIFF
--- a/.github/workflows/cd-manager.yml
+++ b/.github/workflows/cd-manager.yml
@@ -76,6 +76,7 @@ jobs:
         uses: dagger/dagger-for-github@v3
         with:
           install-only: true
+          version: "0.2.36"
       -
         name: Setup Dagger
         run: |


### PR DESCRIPTION
Pin the dagger version to 0.2.36 to prevent gh actions from breaking