### PR TITLE
feat(anchor): add CASv5 env var

### DIFF
--- a/cd/manager/aws/dynamoDb.go
+++ b/cd/manager/aws/dynamoDb.go
@@ -53,7 +53,7 @@ func NewDynamoDb(cfg aws.Config, cache manager.Cache) manager.Database {
 		cache,
 		time.UnixMilli(0),
 	}
-	if err := db.createTable(); err != nil {
+	if err = db.createTable(); err != nil {
 		log.Fatalf("dynamodb: table creation failed: %v", err)
 	}
 	return db

--- a/cd/manager/models.go
+++ b/cd/manager/models.go
@@ -73,6 +73,7 @@ const (
 	JobParam_Delayed   string = "delayed"
 	JobParam_Stalled   string = "stalled"
 	JobParam_Source    string = "source"
+	JobParam_Version   string = "version"
 )
 
 type DeployComponent string


### PR DESCRIPTION
Add a new env var when launching an anchor worker if "version = 5" is passed in the job params.