### PR TITLE
feat: use labels to select workflow job notification channels

### DIFF
--- a/cd/manager/common/job/job.go
+++ b/cd/manager/common/job/job.go
@@ -125,7 +125,7 @@ func CreateWorkflowJob(jobState JobState) (Workflow, error) {
 	} else if workflow, found := jobState.Params[WorkflowJobParam_Workflow].(string); !found {
 		return Workflow{}, fmt.Errorf("missing workflow")
 	} else {
-		workflowInputs := make(map[string]interface{}, 0)
+		workflowInputs := make(map[string]interface{})
 		if inputs, found := jobState.Params[WorkflowJobParam_Inputs].(map[string]interface{}); found {
 			workflowInputs = inputs
 		}
@@ -134,6 +134,14 @@ func CreateWorkflowJob(jobState JobState) (Workflow, error) {
 		if id, found := jobState.Params[JobParam_Id].(float64); found {
 			workflowRunId = int64(id)
 		}
-		return Workflow{org, repo, workflow, ref, workflowInputs, workflowRunUrl, workflowRunId}, nil
+		workflowLabels := make([]string, 0)
+		if labels, found := jobState.Params[WorkflowJobParam_Labels].([]interface{}); found {
+			for _, label := range labels {
+				if l, ok := label.(string); ok {
+					workflowLabels = append(workflowLabels, l)
+				}
+			}
+		}
+		return Workflow{org, repo, workflow, ref, workflowInputs, workflowRunUrl, workflowRunId, workflowLabels}, nil
 	}
 }

--- a/cd/manager/common/job/models.go
+++ b/cd/manager/common/job/models.go
@@ -74,6 +74,12 @@ const (
 	WorkflowJobParam_Url          string = "url"
 	WorkflowJobParam_JobId        string = "job_id"
 	WorkflowJobParam_TestSelector string = "test_selector"
+	WorkflowJobParam_Labels       string = "labels"
+)
+
+const (
+	WorkflowJobLabel_Test   string = "test"
+	WorkflowJobLabel_Deploy string = "deploy"
 )
 
 // JobState represents the state of a job in the database
@@ -95,4 +101,5 @@ type Workflow struct {
 	Inputs   map[string]interface{}
 	Url      string
 	Id       int64
+	Labels   []string
 }

--- a/cd/manager/notifs/discord.go
+++ b/cd/manager/notifs/discord.go
@@ -88,6 +88,27 @@ func parseDiscordWebhookUrl(urlEnv string) (webhook.Client, error) {
 	return nil, nil
 }
 
+func webhooksForLabels(labels []string) ([]webhook.Client, error) {
+	webhooks := make([]webhook.Client, 0)
+	for _, label := range labels {
+		switch label {
+		case job.WorkflowJobLabel_Test:
+			if t, err := parseDiscordWebhookUrl("DISCORD_TESTS_WEBHOOK"); err != nil {
+				return nil, err
+			} else {
+				webhooks = append(webhooks, t)
+			}
+		case job.WorkflowJobLabel_Deploy:
+			if t, err := parseDiscordWebhookUrl("DISCORD_DEPLOYMENTS_WEBHOOK"); err != nil {
+				return nil, err
+			} else {
+				webhooks = append(webhooks, t)
+			}
+		}
+	}
+	return webhooks, nil
+}
+
 func (n JobNotifs) NotifyJob(jobs ...job.JobState) {
 	for _, jobState := range jobs {
 		if jn, err := n.getJobNotif(jobState); err != nil {


### PR DESCRIPTION
This PR is the most surgical change to the CD manager to split notifications. I punted on making a more complicated, deeper change for now.

Labels will have to be passed through when creating `workflow` type jobs so I'm creating separate PRs for that.