### PR TITLE
feat: use same image for cas api/workers and send worker discord notifs

### DIFF
--- a/cd/manager/jobs/deploy.go
+++ b/cd/manager/jobs/deploy.go
@@ -55,7 +55,6 @@ const (
 )
 
 const defaultFailureTime = 30 * time.Minute
-const anchorWorkerRepo = "ceramic-prod-cas-runner"
 
 func DeployJob(jobState job.JobState, db manager.Database, notifs manager.Notifs, d manager.Deployment, repo manager.Repository) (manager.JobSm, error) {
 	if component, found := jobState.Params[job.DeployJobParam_Component].(string); !found {
@@ -235,7 +234,6 @@ func (d deployJob) generateEnvLayout(component manager.DeployComponent) (*manage
 		if component == manager.DeployComponent_Cas {
 			newLayout.Clusters[casCluster].Tasks = &manager.TaskSet{Tasks: map[string]*manager.Task{
 				casCluster + "-" + serviceSuffix_CasWorker: {
-					Repo: &manager.Repo{Name: anchorWorkerRepo},
 					Temp: true, // Anchor workers do not stay up permanently
 					Name: containerName_CasWorker,
 				},

--- a/cd/manager/models.go
+++ b/cd/manager/models.go
@@ -139,7 +139,7 @@ type Cache interface {
 type Deployment interface {
 	LaunchServiceTask(cluster, service, family, container string, overrides map[string]string) (string, error)
 	LaunchTask(cluster, family, container, vpcConfigParam string, overrides map[string]string) (string, error)
-	CheckTask(cluster, taskDefId string, running, stable bool, taskIds ...string) (bool, error)
+	CheckTask(cluster, taskDefId string, running, stable bool, taskIds ...string) (bool, *int32, error)
 	GetLayout(clusters []string) (*Layout, error)
 	UpdateLayout(*Layout, string) error
 	CheckLayout(*Layout) (bool, error)

--- a/cd/manager/notifs/anchor.go
+++ b/cd/manager/notifs/anchor.go
@@ -18,6 +18,7 @@ type anchorNotif struct {
 	state          job.JobState
 	alertWebhook   webhook.Client
 	warningWebhook webhook.Client
+	infoWebhook    webhook.Client
 	region         string
 	env            string
 }
@@ -27,11 +28,14 @@ func newAnchorNotif(jobState job.JobState) (jobNotif, error) {
 		return nil, err
 	} else if w, err := parseDiscordWebhookUrl("DISCORD_WARNING_WEBHOOK"); err != nil {
 		return nil, err
+	} else if i, err := parseDiscordWebhookUrl("DISCORD_INFO_WEBHOOK"); err != nil {
+		return nil, err
 	} else {
 		return &anchorNotif{
 			jobState,
 			a,
 			w,
+			i,
 			os.Getenv("AWS_REGION"),
 			os.Getenv(manager.EnvVar_Env),
 		}, nil
@@ -39,30 +43,20 @@ func newAnchorNotif(jobState job.JobState) (jobNotif, error) {
 }
 
 func (a anchorNotif) getChannels() []webhook.Client {
-	// We only care about "waiting" notifications from the CD manager for the time being. Other notifications are sent
-	// directly from the anchor worker.
-	if a.state.Stage == job.JobStage_Waiting {
-		webhooks := make([]webhook.Client, 0, 1)
-		if stalled, _ := a.state.Params[job.AnchorJobParam_Stalled].(bool); stalled {
-			webhooks = append(webhooks, a.alertWebhook)
-		} else if delayed, _ := a.state.Params[job.AnchorJobParam_Delayed].(bool); delayed {
-			webhooks = append(webhooks, a.warningWebhook)
-		}
+	webhooks := make([]webhook.Client, 0, 1)
+	switch a.state.Stage {
+	case job.JobStage_Started:
+		webhooks = append(webhooks, a.infoWebhook)
+	case job.JobStage_Completed:
+		webhooks = append(webhooks, a.infoWebhook)
+	case job.JobStage_Failed:
+		webhooks = append(webhooks, a.alertWebhook)
 	}
 	return nil
 }
 
 func (a anchorNotif) getTitle() string {
-	jobStageRepr := string(a.state.Stage)
-	// If "waiting", update the job stage representation to qualify the severity of the delay, if applicable.
-	if a.state.Stage == job.JobStage_Waiting {
-		if stalled, _ := a.state.Params[job.AnchorJobParam_Stalled].(bool); stalled {
-			jobStageRepr = job.AnchorJobParam_Stalled
-		} else if delayed, _ := a.state.Params[job.AnchorJobParam_Delayed].(bool); delayed {
-			jobStageRepr = job.AnchorJobParam_Delayed
-		}
-	}
-	return fmt.Sprintf("Anchor Worker %s", strings.ToUpper(jobStageRepr))
+	return fmt.Sprintf("Anchor Worker %s", strings.ToUpper(string(a.state.Stage)))
 }
 
 func (a anchorNotif) getFields() []discord.EmbedField {
@@ -70,13 +64,6 @@ func (a anchorNotif) getFields() []discord.EmbedField {
 }
 
 func (a anchorNotif) getColor() discordColor {
-	if a.state.Stage == job.JobStage_Waiting {
-		if stalled, _ := a.state.Params[job.AnchorJobParam_Stalled].(bool); stalled {
-			return discordColor_Alert
-		} else if delayed, _ := a.state.Params[job.AnchorJobParam_Delayed].(bool); delayed {
-			return discordColor_Warning
-		}
-	}
 	return colorForStage(a.state.Stage)
 }
 

--- a/cd/manager/notifs/discord.go
+++ b/cd/manager/notifs/discord.go
@@ -271,9 +271,6 @@ func (n JobNotifs) getActiveJobs(jobState job.JobState) []discord.EmbedField {
 	if field, found := n.getActiveJobsByType(jobState, job.JobType_Deploy); found {
 		fields = append(fields, field)
 	}
-	if field, found := n.getActiveJobsByType(jobState, job.JobType_Anchor); found {
-		fields = append(fields, field)
-	}
 	if field, found := n.getActiveJobsByType(jobState, job.JobType_TestE2E); found {
 		fields = append(fields, field)
 	}

--- a/ci/plans/cas.cue
+++ b/ci/plans/cas.cue
@@ -62,11 +62,6 @@ dagger.#Plan & {
 			source: _source
 		}
 
-		_runnerImage: docker.#Dockerfile & {
-			target: "runner"
-			source: _source
-		}
-
 		verify: {
 			_endpoint:  "api/v0/healthcheck"
 			_port:      8081
@@ -177,16 +172,6 @@ dagger.#Plan & {
 								TAGS:           _tags + _extraTags + ["qa"]
 							}
 						}
-						_runner: utils.#ECR & {
-							img: _runnerImage.output
-							env: {
-								AWS_ACCOUNT_ID: client.env.AWS_ACCOUNT_ID
-								AWS_ECR_SECRET: client.commands.aws.stdout
-								AWS_REGION:     Region
-								REPO:           "ceramic-prod-cas-runner"
-								TAGS:           _tags + _extraTags + ["qa"]
-							}
-						}
 					}
 				}
 				_base: utils.#ECR & {
@@ -196,16 +181,6 @@ dagger.#Plan & {
 						AWS_ECR_SECRET: client.commands.aws.stdout
 						AWS_REGION:     Region
 						REPO:           "ceramic-prod-cas"
-						TAGS:           _tags + _extraTags
-					}
-				}
-				_runner: utils.#ECR & {
-					img: _runnerImage.output
-					env: {
-						AWS_ACCOUNT_ID: client.env.AWS_ACCOUNT_ID
-						AWS_ECR_SECRET: client.commands.aws.stdout
-						AWS_REGION:     Region
-						REPO:           "ceramic-prod-cas-runner"
 						TAGS:           _tags + _extraTags
 					}
 				}


### PR DESCRIPTION
- Added exit code when checking for ECS task status, so that we can detect non-zero exit codes.
- Remove list of anchor workers from in-progress jobs because that was causing Discord messages to get too large.
- Send anchor worker started/completed/failed Discord notifications since we're removing the separate runner image that sent those notifications.
- Use base image when updating worker task def during CAS deployments.
- Don't push CAS runner image to ECR since it's no longer needed.